### PR TITLE
[issue #261] Run media scanner on all exported files

### DIFF
--- a/src/me/guillaumin/android/osmtracker/gpx/ExportTrackTask.java
+++ b/src/me/guillaumin/android/osmtracker/gpx/ExportTrackTask.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.io.Writer;
 import java.net.URLEncoder;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.TimeZone;
 import java.util.regex.Pattern;
@@ -27,6 +28,7 @@ import android.content.DialogInterface;
 import android.content.DialogInterface.OnClickListener;
 import android.content.Intent;
 import android.database.Cursor;
+import android.media.MediaScannerConnection;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Environment;
@@ -242,8 +244,13 @@ public abstract class ExportTrackTask  extends AsyncTask<Void, Long, Boolean> {
 					cWayPoints.close();
 				}
 
-				// Force rescan of GPX file
-				context.sendBroadcast(new Intent(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE, Uri.fromFile(trackFile)));
+				// Force rescan of directory
+				ArrayList<String> files = new ArrayList<String>();
+				for (File file: trackGPXExportDirectory.listFiles())
+					files.add(file.getAbsolutePath());
+				String[] filesArray = new String[files.size()];
+				filesArray = files.toArray(filesArray);
+				MediaScannerConnection.scanFile(context, filesArray, null, null);
 
 			}
 		} else {

--- a/src/me/guillaumin/android/osmtracker/util/FileSystemUtils.java
+++ b/src/me/guillaumin/android/osmtracker/util/FileSystemUtils.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import android.media.MediaScannerConnection;
 import android.util.Log;
 
 public final class FileSystemUtils {
@@ -20,7 +21,14 @@ public final class FileSystemUtils {
 	private static final int DELETE_MAX_RECURSION_DEPTH = 1;
 	
 	/**
-	 * Copy copy file sourceFile to the directory destination directory
+	 * @brief Copies file sourceFile to the directory destination directory.
+	 * 
+	 * After this method returns, the caller should trigger a media scan to ensure the copied files
+	 * are known to the media scanner and visible over MTP. This can be done by broadcasting an
+	 * {@code Intent.ACTION_MEDIA_SCANNER_SCAN_FILE} with the URI of the new file, or by calling
+	 * {@code MediaScannerConnection.scanFile(file, null)}, passing the full path to the newly added
+	 * file as the {@code file} argument.
+	 * 
 	 * @param destinationDirectory location where the file to be copied
 	 * @param sourceFile the location of the file to copy
 	 * @param targetFileName name of the target file
@@ -65,7 +73,13 @@ public final class FileSystemUtils {
 	}
 
 	/**
-	 * copies all files within a directory to another directory
+	 * @brief Copies all files within a directory to another directory
+	 * 
+	 * After this method returns, the caller should trigger a media scan to ensure the copied files
+	 * are known to the media scanner and visible over MTP. This can be done by calling
+	 * {@code MediaScannerConnection.scanFile(context, files, null, null)}, passing an array of the
+	 * newly added files as the {@code files} argument.
+	 * 
 	 * @param destinationDirectory the target directory
 	 * @param sourceDirectory the source directory 
 	 * @return true if all contents were copied successfully, false otherwise


### PR DESCRIPTION
As discussed, here's the merge request with the code changes I originally proposed. To avoid future uses of the file handling routines suffering from the same bug, I have documented the requirement to perform a media scan after calling one of the methods in question.

On a side note: at first glance, it looked like `MediaScannerConnection.scanFile(file, mimeType)` could solve all our problems by scanning a single file without requiring a context – alas, it requires an instance of `MediaScannerConnection`, whose constructor requires – guess what – a `Context`.