### PR TITLE
fixes gradle error while building apk

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.5-all.zip


### PR DESCRIPTION
This fixes the error:
`Error:Failed to complete Gradle execution.
Cause:
The version of Gradle you are using (2.14.1) does not support the forTasks() method on BuildActionExecuter. Support for this is available in Gradle 3.5 and all later versions.`
When trying to build the APK from Android Studio