### PR TITLE
source code repository URL to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [<img alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png' height="80"/>](https://play.google.com/store/apps/details?id=me.guillaumin.android.osmtracker)
 [<img src="https://f-droid.org/badge/get-it-on.png" alt="Get it on F-Droid" height="80">](https://f-droid.org/app/me.guillaumin.android.osmtracker)
 
-This is the source repository for OSMTracker for Android™.
+OSMTracker for Android&trade; official source code repository is [github.com/nguillaumin/osmtracker-android](https://github.com/nguillaumin/osmtracker-android).
 
 [![Build Status](https://travis-ci.org/nguillaumin/osmtracker-android.svg?branch=master)](https://travis-ci.org/nguillaumin/osmtracker-android)
 


### PR DESCRIPTION
This PR only add to the README file the URL of the official source code repository of OSM Tracker. 